### PR TITLE
stacktrace: Remove addrmap item on release

### DIFF
--- a/stacktrace.cc
+++ b/stacktrace.cc
@@ -86,6 +86,9 @@ void release_backtrace(void* addr)
 		// The stackmap for the given stacktrace is no longer needed.
 		stackmap.erase(stackit);
 	}
+
+	// The given address is released so remove it from addrmap.
+	addrmap.erase(addrit);
 }
 
 static void print_backtrace_symbol(int count, void *addr)

--- a/stacktrace.cc
+++ b/stacktrace.cc
@@ -83,9 +83,8 @@ void release_backtrace(void* addr)
 	stack_info.total_size -= object_info.size;
 	stack_info.count--;
 	if (stack_info.count == 0) {
-		const auto& it = stackmap.find(stack_trace);
-		if (it != stackmap.end())
-			stackmap.erase(it);
+		// The stackmap for the given stacktrace is no longer needed.
+		stackmap.erase(stackit);
 	}
 }
 


### PR DESCRIPTION
Remove addrmap item on release
Remove unnecessary(duplicated) find operation on erasing stackmap item
Add unlikely macro for performance