### PR TITLE
libheaptrace: Add dual sorted reporting feature

### DIFF
--- a/heaptrace.cc
+++ b/heaptrace.cc
@@ -31,7 +31,7 @@ enum options {
 static struct argp_option heaptrace_options[] = {
 	{ "help", 'h', 0, 0, "Give this help list" },
 	{ "top", OPT_top, "NUM", 0, "Set number of top backtraces to show (default 10)" },
-	{ "sort", 's', "KEY", 0, "Sort backtraces based on KEY (size or count)" },
+	{ "sort", 's', "KEY", 0, "Sort backtraces based on KEY (size, count or dual)" },
 	{ "flame-graph", OPT_flamegraph, 0, 0, "Print heap trace info in flamegraph format" },
 	{ "outfile", OPT_outfile, "FILE", 0, "Save log messages to this file" },
 	{ 0 }

--- a/libheaptrace.cc
+++ b/libheaptrace.cc
@@ -126,6 +126,8 @@ static void heaptrace_fini()
 		order = ALLOC_COUNT;
 
 	dump_stackmap(order, opts.flamegraph);
+	if (!strcmp(opts.sortkey, "dual"))
+		dump_stackmap(ALLOC_COUNT, opts.flamegraph);
 
 	if (opts.outfile)
 		fclose(outfp);


### PR DESCRIPTION
Add `dual` option for sort feature
`dual` option will report `size` as well as `count` sorted results.
Usage example:
```
$ heaptrace --sort dual a.out
```

This PR is to resolve following issue.
https://github.com/honggyukim/heaptrace/issues/9

In fact, I'm reluctant on this patch.
First, the code is clean but not readable(in my opinion).
Second, the report is not kind to user.