### PR TITLE
stacktrace: Print offset of binary instead of address

### DIFF
--- a/stacktrace.cc
+++ b/stacktrace.cc
@@ -127,9 +127,8 @@ static void print_backtrace_symbol(int count, void *addr)
 		free(symbol);
 	}
 	else {
-		// TODO: It'd be better to print related address based on its
-		//       load address.  It needs to calculate the load base.
-		pr_out("%s (+%p)\n", dlip.dli_fname, addr);
+		offset = (int)((char*)addr - (char*)(dlip.dli_fbase));
+		pr_out("%s (+%#x)\n", dlip.dli_fname, offset);
 	}
 }
 


### PR DESCRIPTION
It'd be better to print related address based on its load address.
It needs to calculate the load base and print offset instead of address.

Without this patch
```
 0 [0x7f4993dd460f] malloc +0x1f
 1 [0x55d3bc1e81bf] main +0x5
 2 [0x7f4993bc7d90] /lib/x86_64-linux-gnu/libc.so.6 (+0x7f4993bc7d90)
 3 [0x7f4993bc7e40] __libc_start_main +0x20
 4 [0x55d3bc1e80e5] _start +0x9
```

With this commit
```
 0 [0x7f67b66bf60f] malloc +0x1f
 1 [0x5645cb2cc1bf] main +0x5
 2 [0x7f67b64b2d90] /lib/x86_64-linux-gnu/libc.so.6 (+0x29d90)
 3 [0x7f67b64b2e40] __libc_start_main +0x20
 4 [0x5645cb2cc0e5] _start +0x9
```