### PR TITLE
stacktrace: Print binary even if symbol name found

### DIFF
--- a/src/stacktrace.cc
+++ b/src/stacktrace.cc
@@ -121,13 +121,11 @@ static void print_backtrace_symbol(int count, void *addr)
 		}
 		offset = static_cast<int>(static_cast<int *>(addr) -
 					  static_cast<int *>(dlip.dli_saddr));
-		pr_out("%s +%#x\n", symbol, offset);
+		pr_out("%s +%#x ", symbol, offset);
 		free(symbol);
 	}
-	else {
-		offset = (int)((char *)addr - (char *)(dlip.dli_fbase));
-		pr_out("%s (+%#x)\n", dlip.dli_fname, offset);
-	}
+	offset = (int)((char *)addr - (char *)(dlip.dli_fbase));
+	pr_out("(%s +%#x)\n", dlip.dli_fname, offset);
 }
 
 static void print_backtrace_symbol_flamegraph(void *addr, const char *semicolon)


### PR DESCRIPTION
Print executable or library name and its' offset, even if heaptrace found the symbol name and its' offset.
User could find the location of the symbol easily with this patch.

Changed the way to report. Consider,
A: symbol name
B: symbol offset
C: executable or library name
D: executable or library offset

In case of symbol name found:
`A +B (C +D)`
In case of symbol name not found:
`(C +D)`

Without this commit:
```
 0 [0x7f67b66bf60f] malloc +0x1f
 1 [0x5645cb2cc1bf] main +0x5
 2 [0x7f67b64b2d90] /lib/x86_64-linux-gnu/libc.so.6 (+0x29d90)
 3 [0x7f67b64b2e40] __libc_start_main +0x20
 4 [0x5645cb2cc0e5] _start +0x9
```

With this commit:
```
 0 [0x7f060eb2a60f] malloc +0x1f (./libheaptrace.so +0x460f)
 1 [0x5603bfdb11bf] main +0x5 (samples/sample_leak.out +0x11bf)
 2 [0x7f060e91dd90] (/lib/x86_64-linux-gnu/libc.so.6 +0x29d90)
 3 [0x7f060e91de40] __libc_start_main +0x20 (/lib/x86_64-linux-gnu/libc.so.6 +0x29e40)
 4 [0x5603bfdb10e5] _start +0x9 (samples/sample_leak.out +0x10e5)
```

User could easily know that `__libc_start_main` function can be found on `/lib/x86_64-linux-gnu/libc.so.6`