### PR TITLE
build: Add CMakeLists.txt for cmake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ heaptrace
 *.out
 *.patch
 *.swp
+CMake*
+cmake_install.cmake
+compile_commands.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@ repos:
     rev: v14.0.6
     hooks:
     -   id: clang-format
+-   repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+    -   id: cmake-format
+    -   id: cmake-lint

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0
+
+cmake_minimum_required(VERSION 3.10)
+
+project(heaptrace)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_compile_options("-Wno-psabi")
+
+if(NOT DEFINED DEPTH)
+  set(DEPTH 8)
+endif(NOT DEFINED DEPTH)
+add_compile_definitions(DEPTH=${DEPTH})
+
+add_library(libheaptrace SHARED src/libheaptrace.cc src/stacktrace.cc
+                                src/sighandler.cc src/utils.cc)
+set_property(TARGET libheaptrace PROPERTY OUTPUT_NAME heaptrace)
+
+add_executable(heaptrace src/heaptrace.cc)


### PR DESCRIPTION
This patch adds cmake build support and basic usages are as follows.
```
  $ cmake -B out
  $ make -C out
```
If you want to change the depth of stacktrace, then DEPTH variable can
be provided as follows.
```
  $ cmake -B out -DDEPTH=32
  $ make -C out
```
If DEPTH is not given, then the default depth is 8 as written in
CMakeLists.txt.

We don't remove the existing Make build until we're sure that cmake
looks stable enough.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>