### PR TITLE
clang-tidy: Add .clang-tidy config file and use it to refine code base

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,44 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           'false'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           'false'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             cert-err33-c.CheckedFunctions
+    value:           '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s;'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           'false'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           'true'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           'false'
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           'false'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,15 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*'
+Checks: >-
+    clang-diagnostic-*,
+    clang-analyzer-*,
+    bugprone-*,
+    -bugprone-reserved-identifier,
+    -bugprone-suspicious-semicolon,
+    modernize-*,
+    -modernize-avoid-c-arrays,
+    -modernize-redundant-void-arg,
+    -modernize-use-trailing-return-type,
+    -modernize-use-using,
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >-
     -modernize-redundant-void-arg,
     -modernize-use-trailing-return-type,
     -modernize-use-using,
+    performance-*,
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,11 @@ Checks: >-
     -modernize-use-trailing-return-type,
     -modernize-use-using,
     performance-*,
+    readability-*,
+    -readability-braces-around-statements,
+    -readability-else-after-return,
+    -readability-identifier-length,
+    -readability-implicit-bool-conversion,
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/src/heaptrace.cc
+++ b/src/heaptrace.cc
@@ -114,7 +114,6 @@ static void setup_child_environ(struct opts *opts, int argc, char *argv[])
 	std::stringstream ss;
 	char buf[4096];
 	char *old_preload = getenv("LD_PRELOAD");
-	char *old_libpath = getenv("LD_LIBRARY_PATH");
 
 	if (!access("libheaptrace.so", X_OK))
 		ss << "./";

--- a/src/heaptrace.cc
+++ b/src/heaptrace.cc
@@ -1,9 +1,9 @@
 /* Copyright (c) 2022 LG Electronics Inc. */
 /* SPDX-License-Identifier: GPL-2.0 */
 #include <argp.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <unistd.h>
 
 #include <sstream>
@@ -29,17 +29,17 @@ enum options {
 };
 
 static struct argp_option heaptrace_options[] = {
-	{ "help", 'h', 0, 0, "Give this help list" },
+	{ "help", 'h', nullptr, 0, "Give this help list" },
 	{ "top", OPT_top, "NUM", 0, "Set number of top backtraces to show (default 10)" },
 	{ "sort", 's', "KEYs", 0, "Sort backtraces based on KEYs (size or count)" },
-	{ "flame-graph", OPT_flamegraph, 0, 0, "Print heap trace info in flamegraph format" },
+	{ "flame-graph", OPT_flamegraph, nullptr, 0, "Print heap trace info in flamegraph format" },
 	{ "outfile", OPT_outfile, "FILE", 0, "Save log messages to this file" },
-	{ 0 }
+	{ nullptr }
 };
 
 static error_t parse_option(int key, char *arg, struct argp_state *state)
 {
-	struct opts *opts = (struct opts *)state->input;
+	auto *opts = (struct opts *)state->input;
 
 	switch (key) {
 	case 'h':
@@ -47,7 +47,7 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 		break;
 
 	case OPT_top:
-		opts->top = strtol(arg, NULL, 0);
+		opts->top = strtol(arg, nullptr, 0);
 		break;
 
 	case 's':
@@ -66,7 +66,7 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 		if (state->arg_num)
 			return ARGP_ERR_UNKNOWN;
 
-		if (opts->exename == NULL) {
+		if (opts->exename == nullptr) {
 			// remaining options will be processed in ARGP_KEY_ARGS
 			return ARGP_ERR_UNKNOWN;
 		}
@@ -106,7 +106,7 @@ static void init_options(int argc, char *argv[])
 	opts.sort_keys = "size";
 	opts.flamegraph = false;
 
-	argp_parse(&argp, argc, argv, ARGP_IN_ORDER, NULL, &opts);
+	argp_parse(&argp, argc, argv, ARGP_IN_ORDER, nullptr, &opts);
 }
 
 static void setup_child_environ(struct opts *opts, int argc, char *argv[])

--- a/src/heaptrace.cc
+++ b/src/heaptrace.cc
@@ -47,7 +47,7 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 		break;
 
 	case OPT_top:
-		opts->top = strtol(arg, nullptr, 0);
+		opts->top = std::stoi(arg);
 		break;
 
 	case 's':

--- a/src/heaptrace.h
+++ b/src/heaptrace.h
@@ -3,7 +3,7 @@
 #ifndef HEAPTRACE_HEAPTRACE_H
 #define HEAPTRACE_HEAPTRACE_H
 
-#include <stdio.h>
+#include <cstdio>
 
 extern FILE *outfp;
 

--- a/src/libheaptrace.cc
+++ b/src/libheaptrace.cc
@@ -3,12 +3,12 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
+#include <csignal>
 #include <dlfcn.h>
-#include <signal.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
@@ -90,13 +90,13 @@ __constructor static void heaptrace_init()
 	// setup option values
 	// TODO: create constexpr variables instead of default magic values.
 	env = getenv("HEAPTRACE_NUM_TOP_BACKTRACE");
-	opts.top = env ? strtol(env, NULL, 0) : 10;
+	opts.top = env ? strtol(env, nullptr, 0) : 10;
 
 	env = getenv("HEAPTRACE_SORT_KEYS");
 	opts.sort_keys = env ? env : "size";
 
 	env = getenv("HEAPTRACE_FLAME_GRAPH");
-	opts.flamegraph = env ? strtol(env, NULL, 0) : false;
+	opts.flamegraph = env ? strtol(env, nullptr, 0) : false;
 
 	opts.outfile = getenv("HEAPTRACE_OUTFILE");
 	if (opts.outfile) {

--- a/src/libheaptrace.cc
+++ b/src/libheaptrace.cc
@@ -90,13 +90,13 @@ __constructor static void heaptrace_init()
 	// setup option values
 	// TODO: create constexpr variables instead of default magic values.
 	env = getenv("HEAPTRACE_NUM_TOP_BACKTRACE");
-	opts.top = env ? strtol(env, nullptr, 0) : 10;
+	opts.top = env ? std::stoi(env) : 10;
 
 	env = getenv("HEAPTRACE_SORT_KEYS");
 	opts.sort_keys = env ? env : "size";
 
 	env = getenv("HEAPTRACE_FLAME_GRAPH");
-	opts.flamegraph = env ? strtol(env, nullptr, 0) : false;
+	opts.flamegraph = env ? std::stoi(env) : false;
 
 	opts.outfile = getenv("HEAPTRACE_OUTFILE");
 	if (opts.outfile) {

--- a/src/libheaptrace.cc
+++ b/src/libheaptrace.cc
@@ -68,7 +68,6 @@ FILE *outfp;
 
 __constructor static void heaptrace_init()
 {
-	auto *tfs = &thread_flags;
 	int pid = getpid();
 	std::stringstream ss;
 	std::string comm = utils::get_comm_name();
@@ -169,7 +168,7 @@ __visible_default void *operator new[](size_t size)
 	return p;
 }
 
-__visible_default void operator delete(void *ptr)
+__visible_default void operator delete(void *ptr) noexcept
 {
 	auto *tfs = &thread_flags;
 
@@ -187,7 +186,7 @@ __visible_default void operator delete(void *ptr)
 	tfs->hook_guard = false;
 }
 
-__visible_default void operator delete[](void *ptr)
+__visible_default void operator delete[](void *ptr) noexcept
 {
 	auto *tfs = &thread_flags;
 

--- a/src/sighandler.cc
+++ b/src/sighandler.cc
@@ -25,7 +25,9 @@ static void sigquit_handler(int signo)
 
 void sighandler_init(void)
 {
-	struct sigaction sigusr1, sigusr2, sigquit;
+	struct sigaction sigusr1;
+	struct sigaction sigusr2;
+	struct sigaction sigquit;
 
 	sigusr1.sa_handler = sigusr1_handler;
 	sigemptyset(&sigusr1.sa_mask);

--- a/src/sighandler.cc
+++ b/src/sighandler.cc
@@ -1,6 +1,6 @@
 /* Copyright (c) 2022 LG Electronics Inc. */
 /* SPDX-License-Identifier: GPL-2.0 */
-#include <signal.h>
+#include <csignal>
 
 #include "heaptrace.h"
 #include "stacktrace.h"
@@ -39,12 +39,12 @@ void sighandler_init(void)
 	sigemptyset(&sigquit.sa_mask);
 	sigquit.sa_flags = 0;
 
-	if (sigaction(SIGUSR1, &sigusr1, 0) == -1)
+	if (sigaction(SIGUSR1, &sigusr1, nullptr) == -1)
 		pr_dbg("signal(SIGUSR1) error");
 
-	if (sigaction(SIGUSR2, &sigusr2, 0) == -1)
+	if (sigaction(SIGUSR2, &sigusr2, nullptr) == -1)
 		pr_dbg("signal(SIGUSR2) error");
 
-	if (sigaction(SIGQUIT, &sigquit, 0) == -1)
+	if (sigaction(SIGQUIT, &sigquit, nullptr) == -1)
 		pr_dbg("signal(SIGQUIT) error");
 }

--- a/src/stacktrace.cc
+++ b/src/stacktrace.cc
@@ -307,7 +307,6 @@ print_dump_stackmap_flamegraph(std::vector<std::pair<stack_trace_t, stack_info_t
 	size_t stack_size = sorted_stack.size();
 	for (int i = 0; i < stack_size; i++) {
 		const stack_info_t &info = sorted_stack[i].second;
-		size_t count = info.count;
 		uint64_t size = info.total_size;
 		const char *semicolon = "";
 

--- a/src/stacktrace.cc
+++ b/src/stacktrace.cc
@@ -228,8 +228,8 @@ static std::string get_byte_unit(uint64_t size)
 
 std::string read_statm()
 {
-	int vss, rss, shared;
-	int pagesize_kb = sysconf(_SC_PAGESIZE);
+	long vss, rss, shared;
+	long pagesize_kb = sysconf(_SC_PAGESIZE);
 	std::ifstream fs("/proc/self/statm");
 
 	fs >> vss >> rss >> shared;
@@ -244,7 +244,7 @@ std::string read_statm()
 
 static void print_dump_stackmap_header(const char *sort_key)
 {
-	pr_out("[heaptrace] dump allocation sorted by '%s' for /proc/%d/maps (%s)\n", sort_key,
+	pr_out("[heaptrace] dump allocation sorted by '%s' for /proc/%ld/maps (%s)\n", sort_key,
 	       utils::gettid(), utils::get_comm_name().c_str());
 }
 
@@ -315,7 +315,7 @@ print_dump_stackmap_flamegraph(std::vector<std::pair<stack_trace_t, stack_info_t
 
 		const stack_trace_t &stack_trace = sorted_stack[i].first;
 
-		for (int j = info.stack_depth - 1; j >= 0; j--) {
+		for (size_t j = info.stack_depth - 1; j >= 0; j--) {
 			print_backtrace_symbol_flamegraph(stack_trace[j], semicolon);
 			semicolon = ";";
 		}

--- a/src/stacktrace.cc
+++ b/src/stacktrace.cc
@@ -1,11 +1,11 @@
 /* Copyright (c) 2022 LG Electronics Inc. */
 /* SPDX-License-Identifier: GPL-2.0 */
-#include <inttypes.h>
-#include <limits.h>
+#include <cinttypes>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <malloc.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include <cxxabi.h>
 #include <dlfcn.h>
@@ -105,7 +105,7 @@ static void print_backtrace_symbol(int count, void *addr)
 	pr_out("%2d [%#14lx] ", count, (unsigned long)addr);
 #endif
 
-	symbol = abi::__cxa_demangle(dlip.dli_sname, 0, 0, &status);
+	symbol = abi::__cxa_demangle(dlip.dli_sname, nullptr, nullptr, &status);
 
 	if (status == -2 && !symbol)
 		symbol = strdup(dlip.dli_sname);
@@ -138,7 +138,7 @@ static void print_backtrace_symbol_flamegraph(void *addr, const char *semicolon)
 	// dladdr() translates address to symbolic info.
 	dladdr(addr, &dlip);
 
-	symbol = abi::__cxa_demangle(dlip.dli_sname, 0, 0, &status);
+	symbol = abi::__cxa_demangle(dlip.dli_sname, nullptr, nullptr, &status);
 
 	if (status == -2 && !symbol)
 		symbol = strdup(dlip.dli_sname);
@@ -363,7 +363,7 @@ void dump_stackmap(const char *sort_keys, bool flamegraph)
 		std::lock_guard<std::recursive_mutex> lock(container_mutex);
 
 		for (auto &p : stackmap)
-			sorted_stack.push_back(make_pair(p.first, p.second));
+			sorted_stack.emplace_back(p.first, p.second);
 	}
 
 	if (flamegraph) {

--- a/src/stacktrace.cc
+++ b/src/stacktrace.cc
@@ -228,7 +228,9 @@ static std::string get_byte_unit(uint64_t size)
 
 std::string read_statm()
 {
-	long vss, rss, shared;
+	long vss;
+	long rss;
+	long shared;
 	long pagesize_kb = sysconf(_SC_PAGESIZE);
 	std::ifstream fs("/proc/self/statm");
 

--- a/src/stacktrace.h
+++ b/src/stacktrace.h
@@ -12,8 +12,6 @@
 #include "compiler.h"
 #include "heaptrace.h"
 
-extern struct opts opts;
-
 using stack_trace_t = std::array<void *, DEPTH>;
 using addr_t = void *;
 using time_point_t = std::chrono::steady_clock::time_point;
@@ -51,7 +49,7 @@ inline void record_backtrace(size_t size, void *addr)
 
 void release_backtrace(void *addr);
 
-void dump_stackmap(const char *sort_str, bool flamegraph = false);
+void dump_stackmap(const char *sort_keys, bool flamegraph = false);
 
 void clear_stackmap(void);
 

--- a/src/stacktrace.h
+++ b/src/stacktrace.h
@@ -3,8 +3,8 @@
 #ifndef HEAPTRACE_STACKTRACE_H
 #define HEAPTRACE_STACKTRACE_H
 
+#include <cstdint>
 #include <execinfo.h>
-#include <stdint.h>
 
 #include <array>
 #include <chrono>

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -18,10 +18,12 @@ std::string asprintf(const char *fmt, ...)
 	va_list args;
 	std::string str;
 	char *ptr;
-	int ret;
 
 	va_start(args, fmt);
-	ret = vasprintf(&ptr, fmt, args);
+	if (vasprintf(&ptr, fmt, args) < 0) {
+		va_end(args);
+		return {};
+	}
 	str = ptr;
 	free(ptr);
 	va_end(args);

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -43,7 +43,7 @@ std::string get_comm_name(void)
 	return comm;
 }
 
-std::vector<std::string> string_split(std::string str, char delim)
+std::vector<std::string> string_split(const std::string &str, char delim)
 {
 	std::vector<std::string> vstr;
 	std::stringstream ss(str);

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -34,9 +34,8 @@ std::string get_comm_name(void)
 {
 	std::string comm;
 	std::stringstream ss;
-	int tid = utils::gettid();
 
-	ss << "/proc/" << tid << "/comm";
+	ss << "/proc/" << utils::gettid() << "/comm";
 
 	std::ifstream fs(ss.str());
 	fs >> comm;
@@ -78,7 +77,7 @@ static std::string mmap_string(int val, const struct enum_table *et, int len)
 	/* exact match */
 	for (int i = len - 1; i >= 0; i--) {
 		if (val == et[i].val)
-			return std::string(et[i].str);
+			return { et[i].str };
 	}
 
 	/* OR-ing bit flags */

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,7 +23,7 @@ typedef std::chrono::duration<uint64_t, std::kilo> kilobytes;
 typedef std::chrono::duration<uint64_t, std::mega> megabytes;
 typedef std::chrono::duration<uint64_t, std::giga> gigabytes;
 
-static int gettid(void)
+static long gettid(void)
 {
 	return syscall(SYS_gettid);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -32,7 +32,7 @@ std::string asprintf(const char *fmt, ...);
 
 std::string get_comm_name(void);
 
-std::vector<std::string> string_split(std::string str, char delim);
+std::vector<std::string> string_split(const std::string &str, char delim);
 
 struct enum_table {
 	const char *str;


### PR DESCRIPTION
clang-tidy is very useful when it comes to refine C++ project and this PR adds its configuration file and adopt its suggestions.

The clang-tidy can be executed by the following commands.
```
  $ cmake -B out
  $ run-clang-tidy -fix -header-filter=.* -format -style file -p out
```
The current change was made based on clang-tidy-14.

The full list of checkers can be found at https://clang.llvm.org/extra/clang-tidy/checks/list.html.