### PR TITLE
Add option to change signals

### DIFF
--- a/src/heaptrace.cc
+++ b/src/heaptrace.cc
@@ -26,6 +26,7 @@ enum options {
 	OPT_sort,
 	OPT_flamegraph,
 	OPT_outfile,
+	OPT_signals,
 };
 
 static struct argp_option heaptrace_options[] = {
@@ -34,6 +35,7 @@ static struct argp_option heaptrace_options[] = {
 	{ "sort", 's', "KEYs", 0, "Sort backtraces based on KEYs (size or count)" },
 	{ "flame-graph", OPT_flamegraph, nullptr, 0, "Print heap trace info in flamegraph format" },
 	{ "outfile", OPT_outfile, "FILE", 0, "Save log messages to this file" },
+	{ "signals", OPT_signals, "KEY:NUM", 0, "Add report signal numbers for given each key" },
 	{ nullptr }
 };
 
@@ -60,6 +62,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 
 	case OPT_outfile:
 		opts->outfile = arg;
+		break;
+
+	case OPT_signals:
+		opts->signals = arg;
 		break;
 
 	case ARGP_KEY_ARG:
@@ -136,6 +142,9 @@ static void setup_child_environ(struct opts *opts, int argc, char *argv[])
 
 	if (opts->outfile)
 		setenv("HEAPTRACE_OUTFILE", opts->outfile, 1);
+
+	if (opts->signals)
+		setenv("HEAPTRACE_SIGNALS", opts->signals, 1);
 }
 
 int main(int argc, char *argv[])

--- a/src/heaptrace.h
+++ b/src/heaptrace.h
@@ -42,6 +42,7 @@ struct opts {
 	const char *sort_keys;
 	bool flamegraph;
 	char *outfile;
+	char *signals;
 };
 
 extern opts opts;

--- a/src/sighandler.cc
+++ b/src/sighandler.cc
@@ -40,3 +40,13 @@ void sighandler_init(void)
 	register_sighandler(&sigusr2_handler, SIGUSR2);
 	register_sighandler(&sigquit_handler, SIGQUIT);
 }
+
+void size_sighandler(int /*unused*/)
+{
+	dump_stackmap("size", opts.flamegraph);
+}
+
+void count_sighandler(int /*unused*/)
+{
+	dump_stackmap("count", opts.flamegraph);
+}

--- a/src/sighandler.cc
+++ b/src/sighandler.cc
@@ -1,9 +1,8 @@
 /* Copyright (c) 2022 LG Electronics Inc. */
 /* SPDX-License-Identifier: GPL-2.0 */
-#include <csignal>
-
 #include "heaptrace.h"
 #include "stacktrace.h"
+#include "sighandler.h"
 
 static void sigusr1_handler(int signo)
 {
@@ -23,30 +22,21 @@ static void sigquit_handler(int signo)
 	clear_stackmap();
 }
 
+void register_sighandler(sighandler_t handler, int signo)
+{
+	struct sigaction sig;
+
+	sig.sa_handler = handler;
+	sigemptyset(&sig.sa_mask);
+	sig.sa_flags = 0;
+
+	if (sigaction(signo, &sig, nullptr) == -1)
+		pr_dbg("signal(%d) error", signo);
+}
+
 void sighandler_init(void)
 {
-	struct sigaction sigusr1;
-	struct sigaction sigusr2;
-	struct sigaction sigquit;
-
-	sigusr1.sa_handler = sigusr1_handler;
-	sigemptyset(&sigusr1.sa_mask);
-	sigusr1.sa_flags = 0;
-
-	sigusr2.sa_handler = sigusr2_handler;
-	sigemptyset(&sigusr2.sa_mask);
-	sigusr2.sa_flags = 0;
-
-	sigquit.sa_handler = sigquit_handler;
-	sigemptyset(&sigquit.sa_mask);
-	sigquit.sa_flags = 0;
-
-	if (sigaction(SIGUSR1, &sigusr1, nullptr) == -1)
-		pr_dbg("signal(SIGUSR1) error");
-
-	if (sigaction(SIGUSR2, &sigusr2, nullptr) == -1)
-		pr_dbg("signal(SIGUSR2) error");
-
-	if (sigaction(SIGQUIT, &sigquit, nullptr) == -1)
-		pr_dbg("signal(SIGQUIT) error");
+	register_sighandler(&sigusr1_handler, SIGUSR1);
+	register_sighandler(&sigusr2_handler, SIGUSR2);
+	register_sighandler(&sigquit_handler, SIGQUIT);
 }

--- a/src/sighandler.h
+++ b/src/sighandler.h
@@ -7,5 +7,7 @@
 
 void register_sighandler(sighandler_t handler, int signo);
 void sighandler_init(void);
+void size_sighandler(int);
+void count_sighandler(int);
 
 #endif /* HEAPTOP_SIGHANDLER_H */

--- a/src/sighandler.h
+++ b/src/sighandler.h
@@ -3,6 +3,9 @@
 #ifndef HEAPTOP_SIGHANDLER_H
 #define HEAPTOP_SIGHANDLER_H
 
+#include <csignal>
+
+void register_sighandler(sighandler_t handler, int signo);
 void sighandler_init(void);
 
 #endif /* HEAPTOP_SIGHANDLER_H */


### PR DESCRIPTION
Implementation of issue https://github.com/honggyukim/heaptrace/issues/22

heaptrace uses `SIGUSR1` and `SIGUSR2` to dump allocation status (in terms of size and count respectively) during process running. But the signal handler will not work properly, if the target process uses one or both of the signals.

So I suggest to add option to change signals to dump allocation status. For example,

```
# register signal 33 to dump the allocation status sorted in terms of size
$ heaptrace --signal size:33 ./a.out

# register signal 34 to dump the allocation status sorted in terms of count
$ heaptrace --signal count:34 ./a.out

# register signal 33 and 34 to dump the allocation status sorted in terms of size and count respectively
$ heaptrace --signal size:33,count:34 ./a.out
```